### PR TITLE
ignore signatures for rooms signed by the player

### DIFF
--- a/room-claim-assistant.user.js
+++ b/room-claim-assistant.user.js
@@ -84,7 +84,7 @@ function recalculateClaimOverlay() {
                     state = "owned";
                 } else if (roomStats.own && !userOwned) {
                     state = "prohibited";
-                } else if (roomStats.sign && !userOwned) {
+                } else if (roomStats.sign && !userOwned && roomStats.sign.user !== user._id) {
                     state = "signed";
                 } else if (counts.c.length === 0) {
                     state = "unclaimable";


### PR DESCRIPTION
This way players who sign their own territory can look at the different rooms in their territory without issue, while still seeing when other players have signed rooms as their own.